### PR TITLE
Fix crash when serializing certain meshes and pin pycollada version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pycollada
+pycollada==0.7.1
 toolz>=0.10.0,<0.11.0
 webcolors==1.11.1
 vg>=1.7.0,<2.0

--- a/tri_again/_collada.py
+++ b/tri_again/_collada.py
@@ -36,7 +36,7 @@ def geometry_node_from_mesh(collada, mesh, name):
         collada,
         name or "geometry0",
         str(mesh),
-        [FloatSource(vertex_source_name, mesh.v, ("X", "Y", "Z"))],
+        [FloatSource(vertex_source_name, mesh.v.ravel(), ("X", "Y", "Z"))],
     )
     input_list = InputList()
     input_list.addInput(0, "VERTEX", f"#{vertex_source_name}")


### PR DESCRIPTION
The crash requiring `.ravel()` happened the first time I tried to use this outside of these tests. Not sure why. Normally I'd try to put better coverage on this, though I don't think it's worth it in the case of this library. I'm hoping to migrate to USDZ at some point which will make all of this Collada code obsolete.